### PR TITLE
Update yt-dl article with RIAA claim

### DIFF
--- a/content/posts/2020-05-22-how-to-download-videos-from-private-FB-groups/index.mdx
+++ b/content/posts/2020-05-22-how-to-download-videos-from-private-FB-groups/index.mdx
@@ -91,6 +91,8 @@ Youtube-dl is a tool I sometimes use when I want to download a video from YouTub
 
 This application is written in Python and runs everywhere; I have it installed on my server just in case. While its main features are well documented, individual extractors like Facebook don't have any documentation besides its [source code][facebook-extractor]. The best way to test if youtube-dl can download a video is to try it out and see yourself.
 
+*Update 10/23/2020: youtube-dl source repository has been taken down after the [DMCA notice from RIAA][riaa]. The authors published [on their website][ytdl-website] latest source code archive and binaries; however, the future of this project is uncertain at the moment. I decided to create a repository mirror from its latest snapshot on my own git server. You can find the code [here][ytdl-mirror].*
+
 ### Downloading a protected FB video
 Under normal circumstances, youtube-dl works perfectly for downloading public videos. However, video from a private Facebook group is a different case. If you try to download it, youtube-dl eventually asks you for login credentials:
 
@@ -162,3 +164,6 @@ Please let me know your opinions in the comments.
 [mpeg-dash]: https://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP
 [youtube-dl]: https://ytdl-org.github.io/youtube-dl/index.html
 [facebook-extractor]: https://github.com/ytdl-org/youtube-dl/blob/master/youtube_dl/extractor/facebook.py
+[riaa]: https://github.com/github/dmca/blob/master/2020/10/2020-10-23-RIAA.md
+[ytdl-website]: https://youtube-dl.org/
+[ytdl-mirror]: https://gitlab.darka.sk/vzahradnik/youtube-dl

--- a/content/posts/2020-05-22-how-to-download-videos-from-private-FB-groups/index.sk_SK.mdx
+++ b/content/posts/2020-05-22-how-to-download-videos-from-private-FB-groups/index.sk_SK.mdx
@@ -92,6 +92,8 @@ Youtube-dl je nástroj, ktorý občas používam, keď si chcem stiahnuť z YouT
 
 Táto aplikácia je napísaná v Pythone a beží všade. Pre prípad ju mám nainštalovanú aj na svojom serveri. Zatiaľ čo sú hlavné funkcie dobre zdokumentované, individuálne extraktory ako Facebook nemajú žiadnu dokumentáciu okrem ich [zdrojového kódu][facebook-extractor]. Najlepší spôsob, ako otestovať, či dokáže youtube-dl stiahnuť video, je to jednoducho vyskúšať.
 
+*Aktualizácia 23.10.2020: zdrojový repozitár youtube-dl bol odstránený po [DMCA výzve od organizácie RIAA][riaa]. Autori [na ich webstránke][ytdl-website] zverejnili archív najnovšieho zdrojového kódu a binárky. Avšak v tejto chvíli je budúcnosť projektu neistá. Rozhodol som sa preto vytvoriť zrkadlo repozitára z jeho poslednej zálohy na mojom vlastnom git serveri. Kód nájdete [tu][ytdl-mirror].*
+
 ### Stiahnutie chráneného FB videa
 Za normálnych okolností funguje youtube-dl perfektne na sťahovanie verejných videí. Avšak video zo súkromnej skupiny na Facebooku je iný prípad. Pokiaľ sa ho pokúsite stiahnuť, youtube-dl vás nakoniec požiada o prihlasovacie údaje:
 
@@ -163,3 +165,6 @@ Dajte mi, prosím, vedieť váš názor do komentára.
 [mpeg-dash]: https://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP
 [youtube-dl]: https://ytdl-org.github.io/youtube-dl/index.html
 [facebook-extractor]: https://github.com/ytdl-org/youtube-dl/blob/master/youtube_dl/extractor/facebook.py
+[riaa]: https://github.com/github/dmca/blob/master/2020/10/2020-10-23-RIAA.md
+[ytdl-website]: https://youtube-dl.org/
+[ytdl-mirror]: https://gitlab.darka.sk/vzahradnik/youtube-dl


### PR DESCRIPTION
This PR updates my articles related to `youtube-dl` to explain latest state regarding this tool.

- Last week, RIAA sent a DMCA takedown letter to GitHub, and all the repositories on this platform were taken down as a result
- Authors published the source code archive on their webpage, binaries are also available
- I created a mirror on my own server